### PR TITLE
Use HTTP:18080 as the instance destination for the Rancher ELB

### DIFF
--- a/elb.tf
+++ b/elb.tf
@@ -19,8 +19,8 @@ resource "aws_elb" "rancher_manager" {
   # }
 
   listener {
-    instance_port = 81
-    instance_protocol = "tcp"
+    instance_port = 18080
+    instance_protocol = "http"
     lb_port = 443
     lb_protocol = "ssl"
     ssl_certificate_id = "${var.elb_ssl_cert_id}"


### PR DESCRIPTION
This is intended to be a quick fix for an outage on the instance level. Rancher Manager instances started to fail the ELB health check, which caused them to get rebooted by the ASG. Somehow, the SSL host on port 81 isn't spinning back up. However, port `18080`, the HTTP port, is working fine on the instances .

This is not a solution to the underlying problem, but it is a quick way to get operational again.