### PR TITLE
Revert "Use HTTP:18080 as the instance destination for the Rancher ELB"

### DIFF
--- a/elb.tf
+++ b/elb.tf
@@ -19,8 +19,8 @@ resource "aws_elb" "rancher_manager" {
   # }
 
   listener {
-    instance_port = 18080
-    instance_protocol = "http"
+    instance_port = 81
+    instance_protocol = "tcp"
     lb_port = 443
     lb_protocol = "ssl"
     ssl_certificate_id = "${var.elb_ssl_cert_id}"


### PR DESCRIPTION
Reverts gop/terraform-aws-rancher-server#14